### PR TITLE
Use SWIG to forward C++ exceptions

### DIFF
--- a/python/fmm.i
+++ b/python/fmm.i
@@ -1,4 +1,5 @@
 %module fmm
+%include exception.i
 %include "std_string.i"
 // %include "stdint.i"
 %include "std_vector.i"
@@ -11,6 +12,16 @@
 %ignore FMM::MM::FastMapMatchConfig::print() const;
 %ignore FMM::CONFIG::GPSConfig::print() const;
 %ignore FMM::CONFIG::ResultConfig::print() const;
+
+%exception {
+    try {
+        $action
+    } catch (std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, const_cast<char*>(e.what()));
+    } catch (...) {
+        SWIG_exception(SWIG_RuntimeError, "Unknown error");
+    }
+}
 
 %{
 /* Put header files here or function declarations like below */

--- a/src/mm/fmm/ubodt.cpp
+++ b/src/mm/fmm/ubodt.cpp
@@ -4,8 +4,12 @@
 
 #include "mm/fmm/ubodt.hpp"
 #include "util/util.hpp"
+
 #include <fstream>
+#include <stdexcept>
+
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/format.hpp>
 
 using namespace FMM;
 using namespace FMM::CORE;
@@ -184,9 +188,9 @@ std::shared_ptr<UBODT> UBODT::read_ubodt_file(const std::string &filename,
   } else if (UTIL::check_file_extension(filename,"csv,txt")) {
     return read_ubodt_csv(filename,multiplier);
   } else {
-    SPDLOG_CRITICAL("File format not support: {}",filename);
-    std::exit(EXIT_FAILURE);
-    return nullptr;
+    std::string message = (boost::format("File format not supported: %1%") % filename).str();
+    SPDLOG_CRITICAL(message);
+    throw std::runtime_error(message);
   }
 }
 

--- a/src/network/osm_network_reader.hpp
+++ b/src/network/osm_network_reader.hpp
@@ -52,8 +52,10 @@ inline NETWORK_TYPE string2network_type(const std::string &mode){
   if (mode == "all"){
     return NETWORK_TYPE::ALL;
   }
-  SPDLOG_CRITICAL("Unknown network mode, should be drive|walk|bike|all");
-  std::exit(EXIT_FAILURE);
+
+  std::string message = "Unknown network mode, should be drive|walk|bike|all";
+  SPDLOG_CRITICAL(message);
+  throw std::runtime_error(message);
 };
 
 /**


### PR DESCRIPTION
Avoid usage of exit() to avoid killing python kernels. Replace with
std::runtime_errors. Solves  cyang-kth/fmm#117.