### PR TITLE
Fix MSVC build with Boost older than 1.73

### DIFF
--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -19,9 +19,12 @@ namespace boost {
   BOOST_NORETURN void throw_exception(const std::exception & e) {
     throw e;
   }
+
+#if (BOOST_VERSION / 100) >= 1073
   BOOST_NORETURN void throw_exception(const std::exception & e, boost::source_location const & loc) {
     throw e;
   }
+#endif
 
 } // namespace boost
 


### PR DESCRIPTION
In previous PR (#165) I added instantiation for `boost::throw_exception`. There's a change in version 1.73 of boost, which makes the code failed to build with boost older than 1.73. This PR fixes it.