### PR TITLE
Fix python path in CMakeLists

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 execute_process(
-  COMMAND python -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"
+  COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"
   OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "Python packages ${PYTHON_SITE_PACKAGES}")
 


### PR DESCRIPTION
Use found python executable instead of the default one in the system to determine the installation path