### PR TITLE
Fixed matching on bidirectional edge when reverse movement tolerance was enabled

### DIFF
--- a/src/mm/composite_graph.cpp
+++ b/src/mm/composite_graph.cpp
@@ -30,8 +30,12 @@ DummyGraph::DummyGraph(const Traj_Candidates &traj_candidates,
                    n, c.edge->index, c.offset-iter->second->offset);
         } else if (iter->second->offset - c.offset <
                    c.edge->length * reverse_tolerance) {
+          // reverse movement is discouraged, so it has higher cost than normal
+          // movement.
+          double reverse_movement_cost =
+              (iter->second->offset - c.offset) * (2.0 - reverse_tolerance);
           add_edge(iter->second->index,
-                   n, c.edge->index, 0);
+                   n, c.edge->index, reverse_movement_cost);
         }
       }
     }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -31,7 +31,8 @@ Network::Network(const std::string &filename,
                  const std::string &id_name,
                  const std::string &source_name,
                  const std::string &target_name) {
-  if (FMM::UTIL::check_file_extension(filename, "shp")) {
+  if (FMM::UTIL::check_file_extension(filename, "shp") ||
+      FMM::UTIL::check_file_extension(filename, "gpkg")) {
     read_ogr_file(filename,id_name,source_name,target_name);
   } else {
     std::string message = (boost::format("Network file not supported %1%") % filename).str();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,18 @@ add_executable(fmm_test fmm_test.cpp
 target_link_libraries(fmm_test ${GDAL_LIBRARIES} ${Boost_LIBRARIES}
         ${OpenMP_CXX_LIBRARIES} ${OSMIUM_LIBRARIES})
 
+add_executable(stmatch_test stmatch_test.cpp
+        $<TARGET_OBJECTS:MM_OBJ>
+        $<TARGET_OBJECTS:CORE>
+        $<TARGET_OBJECTS:CONFIG>
+        $<TARGET_OBJECTS:ALGORITHM>
+        $<TARGET_OBJECTS:UTIL>
+        $<TARGET_OBJECTS:IO>
+        $<TARGET_OBJECTS:NETWORK>
+        $<TARGET_OBJECTS:STMATCH_OBJ>)
+target_link_libraries(stmatch_test ${GDAL_LIBRARIES} ${Boost_LIBRARIES}
+        ${OpenMP_CXX_LIBRARIES} ${OSMIUM_LIBRARIES})
+
 add_executable(network_graph_test network_graph_test.cpp
         $<TARGET_OBJECTS:CORE>
         $<TARGET_OBJECTS:CONFIG>
@@ -33,7 +45,7 @@ add_executable(network_test network_test.cpp
         $<TARGET_OBJECTS:IO>
         $<TARGET_OBJECTS:NETWORK>)
 target_link_libraries(network_test ${GDAL_LIBRARIES} ${OpenMP_CXX_LIBRARIES}
-${OSMIUM_LIBRARIES})
+        ${OSMIUM_LIBRARIES})
 
 add_custom_target(tests
-	DEPENDS algorithm_test network_test network_graph_test fmm_test)
+	DEPENDS algorithm_test network_test network_graph_test fmm_test stmatch_test)

--- a/test/fmm_test.cpp
+++ b/test/fmm_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "fmm is tested", "[fmm]" ) {
     MatchResult result = model.match_traj(trajectory,config);
     LineString expected_mgeom = wkt2linestring(
       "LINESTRING(2 0.250988700565,2 1,2 2,3 2,4 2,4 2.45776836158)");
-    REQUIRE_THAT(result.cpath,Catch::Equals<int>({2,5,13,14,23}));
+    REQUIRE_THAT(result.cpath,Catch::Equals<FMM::NETWORK::EdgeID>({2,5,13,14,23}));
     REQUIRE(expected_mgeom==result.mgeom);
   }
 }

--- a/test/stmatch_test.cpp
+++ b/test/stmatch_test.cpp
@@ -1,0 +1,48 @@
+#include "core/geometry.hpp"
+#include "mm/stmatch/stmatch_algorithm.hpp"
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#include "util/debug.hpp"
+#include "network/network.hpp"
+#include "mm/fmm/fmm_algorithm.hpp"
+#include "mm/transition_graph.hpp"
+#include "core/gps.hpp"
+#include "io/gps_reader.hpp"
+
+using namespace FMM;
+using namespace FMM::IO;
+using namespace FMM::CORE;
+using namespace FMM::NETWORK;
+using namespace FMM::MM;
+
+TEST_CASE("stmatch is tested", "[stmatch]") {
+  spdlog::set_level((spdlog::level::level_enum) 0);
+  spdlog::set_pattern("[%l][%s:%-3#] %v");
+
+  SECTION("basic matching") {
+    Network network("../data/network.gpkg");
+    NetworkGraph graph(network);
+    STMATCH stmatch(network, graph);
+    CSVTrajectoryReader reader("../data/trips.csv","id","geom");
+    std::vector<Trajectory> trajectories = reader.read_all_trajectories();
+    const Trajectory &traj = trajectories[0];
+    STMATCHConfig config(4, 0.4, 0.5);
+    MatchResult result = stmatch.match_traj(traj, config);
+    LineString expected_mgeom = wkt2linestring(
+      "LINESTRING(2 0.250988700565,2 1,2 2,3 2,4 2,4 2.45776836158)");
+    REQUIRE_THAT(result.cpath,Catch::Equals<FMM::NETWORK::EdgeID>({2,5,13,14,23}));
+    REQUIRE(expected_mgeom == result.mgeom);
+  }
+
+  SECTION("bidirectional") {
+    Network network("../data/network.gpkg");
+    NetworkGraph graph(network);
+    STMATCH stmatch(network, graph);
+    Trajectory traj(1, wkt2linestring("LINESTRING (1.9 3.5,1.6 3.5,1.5 3.5,1.3 3.5,"
+                                      "1.0 3.5,0.8 3.5,0.6 3.5)"));
+    MatchResult result =
+        stmatch.match_traj(traj, STMATCHConfig(8, 1.0, 1.0, 30, 1.5, 0.5));
+    REQUIRE_THAT(result.cpath, Catch::Equals<FMM::NETWORK::EdgeID>({28}));
+  }
+}


### PR DESCRIPTION
Reverse movement penalties were added to reverse edges. This is for prevending reverse edges from being incorrectly matched. An example for reproducing this issue was added to newly added STMATCH test.

I've also enabled gpkg support in Network module to run the tests, and compile errors on g++-10 were also fixed for all tests.