### PR TITLE
Allow constructing Network object from scratch by calling add_edge

### DIFF
--- a/src/mm/mm_type.hpp
+++ b/src/mm/mm_type.hpp
@@ -30,7 +30,7 @@ struct Candidate
                         numeber of vertices in the graph */
   double offset; /**< offset distance from the start of polyline to p' */
   double dist; /**< distance from original point p to map matched point p' */
-  NETWORK::Edge *edge;  /**< candidate edge */
+  const NETWORK::Edge *edge;  /**< candidate edge */
   FMM::CORE::Point point; /**< boost point */
 };
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -43,12 +43,18 @@ public:
   /**
    * Item stored in a node of Rtree
    */
-  typedef std::pair<boost_box, Edge *> Item;
+  typedef std::pair<boost_box, EdgeIndex> Item;
   /**
    * Rtree of road edges
    */
   typedef boost::geometry::index::rtree<
       Item, boost::geometry::index::quadratic<16> > Rtree;
+
+  /**
+   * Construct an empty network. Nodes and edges can be added later by calling
+   * add_edge.
+   */
+  Network(int srid = 4326);
   /**
    *  Constructor of Network
    *
@@ -66,6 +72,7 @@ public:
         );
   Network(const CONFIG::NetworkConfig &config):Network(
     config.file,config.id,config.source,config.target){};
+
   /**
    * Get number of nodes in the network
    * @return number of nodes
@@ -205,10 +212,7 @@ private:
   static void append_segs_to_line(FMM::CORE::LineString *line,
                                   const FMM::CORE::LineString &segs,
                                   int offset = 0);
-  /**
-   * Build rtree for the network
-   */
-  void build_rtree_index();
+
   int srid;   // Spatial reference id
   Rtree rtree;   // Network rtree structure
   std::vector<Edge> edges;   // all edges in the network


### PR DESCRIPTION
This patch allows `Network` to be constructed from scratching by calling `add_edge`, which makes experimenting with various kinds of road network data much easier.