### PR TITLE
Python3 fixes (maintains python2 compatibility)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(Conda)
 if(CONDA_PREFIX)
   message(STATUS "Set CONDA_PREFIX ${CONDA_PREFIX}")
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${CONDA_PREFIX})
+  set(Python_FIND_STRATEGY LOCATION) # might want to prefer conda over system python
 else()
   message(STATUS "Non conda exist, search library in default path")
 endif()

--- a/example/python/fmm_test.py
+++ b/example/python/fmm_test.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from fmm import Network,NetworkGraph,STMATCH,STMATCHConfig
 network = Network("../data/edges.shp")
 graph = NetworkGraph(network)
-print graph.get_num_vertices()
+print(graph.get_num_vertices())
 model = STMATCH(network,graph)
 wkt = "LINESTRING(0.200812146892656 2.14088983050848,1.44262005649717 2.14879943502825,3.06408898305084 2.16066384180791,3.06408898305084 2.7103813559322,3.70872175141242 2.97930790960452,4.11606638418078 2.62337570621469)"
 config = STMATCHConfig()
@@ -11,7 +12,7 @@ config.radius = 0.4
 config.vmax = 30;
 config.factor =1.5
 result = model.match_wkt(wkt,config)
-print type(result)
-print "Opath ",list(result.opath)
-print "Cpath ",list(result.cpath)
-print "WKT ",result.mgeom.export_wkt()
+print(type(result))
+print("Opath ",list(result.opath))
+print("Cpath ",list(result.cpath))
+print("WKT ",result.mgeom.export_wkt())

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,20 +7,15 @@ else()
   message(FATAL_ERROR "Swig not found!\n")
 endif()
 
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
-if (PYTHONLIBS_FOUND)
-  message(STATUS "Python header found at ${PYTHON_INCLUDE_DIRS}")
-  message(STATUS "Python library found at ${PYTHON_LIBRARIES}")
-  include_directories(${PYTHON_INCLUDE_DIRS})
+find_package(Python COMPONENTS Interpreter Development)
+if (Python_FOUND)
+  message(STATUS "Python header found at ${Python_INCLUDE_DIRS}")
+  message(STATUS "Python library found at ${Python_LIBRARIES}")
+  message(STATUS "Python packages ${Python_SITELIB}")
+  include_directories(${Python_INCLUDE_DIRS})
 else()
   message(FATAL_ERROR "Python library not found!\n")
 endif()
-
-execute_process(
-  COMMAND python -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"
-  OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS "Python packages ${PYTHON_SITE_PACKAGES}")
 
 set_source_files_properties(
 ${PROJECT_SOURCE_DIR}/python/fmm.i PROPERTIES CPLUSPLUS ON)
@@ -28,16 +23,16 @@ ${PROJECT_SOURCE_DIR}/python/fmm.i PROPERTIES CPLUSPLUS ON)
 if (${CMAKE_VERSION} VERSION_LESS 3.13.0)
   message(STATUS "Using swig add module")
   SWIG_ADD_MODULE(fmm python ${PROJECT_SOURCE_DIR}/python/fmm.i)
-  swig_link_libraries(fmm FMMLIB ${PYTHON_LIBRARIES})
-  install(TARGETS ${SWIG_MODULE_fmm_REAL_NAME} DESTINATION ${PYTHON_SITE_PACKAGES})
+  swig_link_libraries(fmm FMMLIB ${Python_LIBRARIES})
+  install(TARGETS ${SWIG_MODULE_fmm_REAL_NAME} DESTINATION ${Python_SITELIB})
 else()
   message(STATUS "Using swig add library")
   SWIG_ADD_LIBRARY(pyfmm
     LANGUAGE python
     SOURCES ${PROJECT_SOURCE_DIR}/python/fmm.i)
   set_property(TARGET pyfmm PROPERTY OUTPUT_NAME fmm)
-  swig_link_libraries(pyfmm FMMLIB ${PYTHON_LIBRARIES})
-  install(TARGETS pyfmm DESTINATION ${PYTHON_SITE_PACKAGES})
+  target_link_libraries(pyfmm FMMLIB Python::Module)
+  install(TARGETS pyfmm DESTINATION ${Python_SITELIB})
 endif()
 
-install(FILES ${CMAKE_BINARY_DIR}/python/fmm.py DESTINATION ${PYTHON_SITE_PACKAGES})
+install(FILES ${CMAKE_BINARY_DIR}/python/fmm.py DESTINATION ${Python_SITELIB})


### PR DESCRIPTION
After some digging, I think I may have resolved the segfault issue on Python>3.6.1 on MacOS (see #179). It has to do with 

1. Linking of necessary python libraries to swig
2. Deprecated `swig_link_libraries` (see https://cmake.org/cmake/help/latest/module/UseSWIG.html in conjunction with https://cmake.org/cmake/help/latest/policy/CMP0078.html)
3. Deprecated `PythonInterp` and `PythonLibs`. Best way to pass libraries to `target_link_libraries` is using `Python::Module` of [`FindPython`](https://cmake.org/cmake/help/latest/module/FindPython.html)

This PR changes `PythonInterp` and `PythonInterp` to prefer `FindPython`, which detects your python library (python 2 or 3) and sets up CMAKE appropriately. It then deprecates `swig_link_libraries` in favor of `target_link_libraries` for CMAKE versions 3.13 and above.

The above changes seem to still be compatible with ubuntu-based python 2 and python 3 installs, while resolving the segfault issues encountered in the python3 install of `fmm` on MacOS.

CI testing might have to be changed a bit to test for python3 since `python` defaults to the python 2 install in most systems.